### PR TITLE
feat: add rule-driven form playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,8 @@
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^1.1.2",
-        "zod": "^4.0.17"
+        "zod": "^4.0.17",
+        "zustand": "^5.0.7"
       },
       "devDependencies": {
         "@types/react": "^18.0.0",
@@ -5121,6 +5122,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.7.tgz",
+      "integrity": "sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
-    "zod": "^4.0.17"
+    "zod": "^4.0.17",
+    "zustand": "^5.0.7"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,5 @@
+import { Playground } from '@/components/playground/Playground';
+
 export default function App(): JSX.Element {
-  return (
-    <div>
-      <h1>Form Renderer POC</h1>
-      <button>Hello World</button>
-    </div>
-  );
+  return <Playground />;
 }

--- a/src/components/devtools/FormDevTool.tsx
+++ b/src/components/devtools/FormDevTool.tsx
@@ -1,0 +1,13 @@
+import { useFormContext } from 'react-hook-form';
+import { useFormStore } from '@/store/formStore';
+
+export function FormDevTool() {
+  const form = useFormContext();
+  const store = useFormStore();
+  const values = form.watch();
+  return (
+    <div className="absolute bottom-2 right-2 w-80 h-64 overflow-auto border rounded bg-background p-2 text-xs">
+      <pre>{JSON.stringify({ values, store }, null, 2)}</pre>
+    </div>
+  );
+}

--- a/src/components/form/FieldRenderer.tsx
+++ b/src/components/form/FieldRenderer.tsx
@@ -1,0 +1,71 @@
+import { useFormContext } from 'react-hook-form';
+import { FieldSchema } from '@/types/form-schema';
+import { useFormStore } from '@/store/formStore';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form';
+
+interface Props {
+  field: FieldSchema;
+}
+
+export function FieldRenderer({ field }: Props) {
+  const form = useFormContext();
+  const { visibleFields, enabledFields } = useFormStore();
+  if (!visibleFields[field.id]) return null;
+  const disabled = !enabledFields[field.id];
+
+  return (
+    <FormField
+      control={form.control}
+      name={field.id}
+      render={({ field: rf }) => (
+        <FormItem>
+          <FormLabel>{field.label}</FormLabel>
+          <FormControl>{renderField(rf)}</FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+
+  function renderField(rf: any) {
+    switch (field.type) {
+      case 'select':
+        return (
+          <Select onValueChange={rf.onChange} value={rf.value} disabled={disabled}>
+            <SelectTrigger>
+              <SelectValue placeholder={field.placeholder} />
+            </SelectTrigger>
+            <SelectContent>
+              {field.options?.map((opt) => (
+                <SelectItem key={opt.value} value={String(opt.value)}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        );
+      case 'checkbox':
+        return (
+          <Checkbox checked={rf.value} onCheckedChange={rf.onChange} disabled={disabled} />
+        );
+      default:
+        return (
+          <Input
+            type={field.type}
+            placeholder={field.placeholder}
+            {...rf}
+            disabled={disabled}
+          />
+        );
+    }
+  }
+}

--- a/src/components/form/FormRenderer.tsx
+++ b/src/components/form/FormRenderer.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo } from 'react';
+import { useForm, FormProvider } from 'react-hook-form';
+import { useFormStore } from '@/store/formStore';
+import { SectionRenderer } from './SectionRenderer';
+import { Button } from '@/components/ui/button';
+import { runRules } from '@/lib/rule-engine';
+import { RuleSchema, FieldSchema } from '@/types/form-schema';
+import { FormDevTool } from '../devtools/FormDevTool';
+
+export function FormRenderer() {
+  const {
+    schema,
+    currentSectionIndex,
+    setCurrentSection,
+    visibleSections,
+    enabledSections,
+    setFieldVisibility,
+    setFieldEnabled,
+    setSectionVisibility,
+    setSectionEnabled,
+    contextValues,
+  } = useFormStore();
+
+  const form = useForm({
+    defaultValues: useMemo(() => {
+      const values: Record<string, any> = {};
+      schema?.sections.forEach((s) =>
+        s.fields.forEach((f) => (values[f.id] = f.defaultValue ?? ''))
+      );
+      return values;
+    }, [schema]),
+  });
+
+  const helpers = {
+    getValue: (field: string) => form.getValues(field),
+    context: contextValues,
+    setFieldVisibility,
+    setFieldEnabled,
+    setSectionVisibility,
+    setSectionEnabled,
+    setValue: form.setValue,
+  };
+
+  // run load rules
+  useEffect(() => {
+    if (!schema) return;
+    schema.sections.forEach((sec) => {
+      runRules(filterRules(sec.rules, 'load'), helpers);
+      sec.fields.forEach((f) => runRules(filterRules(f.rules, 'load'), helpers));
+    });
+  }, [schema]);
+
+  // watch for change rules
+  useEffect(() => {
+    if (!schema) return;
+    const fieldMap: Record<string, FieldSchema> = {};
+    schema.sections.forEach((s) => s.fields.forEach((f) => (fieldMap[f.id] = f)));
+    const subscription = form.watch((_, info) => {
+      const name = info.name as string;
+      const field = fieldMap[name];
+      if (field) {
+        runRules(filterRules(field.rules, 'change'), helpers);
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [schema, form.watch]);
+
+  if (!schema) return null;
+
+  const currentSection = schema.sections[currentSectionIndex];
+
+  const onSubmit = (values: any) => {
+    schema.sections.forEach((sec) =>
+      runRules(filterRules(sec.rules, 'submit'), helpers)
+    );
+    schema.sections.forEach((sec) =>
+      sec.fields.forEach((f) => runRules(filterRules(f.rules, 'submit'), helpers))
+    );
+    console.log('submit', values);
+  };
+
+  return (
+    <div className="flex h-full">
+      <nav className="w-64 border-r p-4 space-y-2">
+        {schema.sections.map((sec, idx) =>
+          visibleSections[sec.id] ? (
+            <Button
+              variant={idx === currentSectionIndex ? 'default' : 'ghost'}
+              key={sec.id}
+              className="w-full justify-start"
+              onClick={() => setCurrentSection(idx)}
+              disabled={!enabledSections[sec.id]}
+            >
+              {sec.title}
+            </Button>
+          ) : null
+        )}
+      </nav>
+      <div className="flex-1 p-6 overflow-y-auto">
+        <FormProvider {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <SectionRenderer section={currentSection} />
+            <div className="flex justify-end gap-2 pt-4">
+              {currentSectionIndex > 0 && (
+                <Button
+                  type="button"
+                  onClick={() => setCurrentSection(currentSectionIndex - 1)}
+                  variant="secondary"
+                >
+                  Previous
+                </Button>
+              )}
+              {currentSectionIndex < schema.sections.length - 1 && (
+                <Button
+                  type="button"
+                  onClick={() => setCurrentSection(currentSectionIndex + 1)}
+                >
+                  Next
+                </Button>
+              )}
+              {currentSectionIndex === schema.sections.length - 1 && (
+                <Button type="submit">Save</Button>
+              )}
+            </div>
+          </form>
+          <FormDevTool />
+        </FormProvider>
+      </div>
+    </div>
+  );
+}
+
+function filterRules(rules: RuleSchema[] | undefined, event: string) {
+  return rules?.filter((r) => r.event === event);
+}

--- a/src/components/form/SectionRenderer.tsx
+++ b/src/components/form/SectionRenderer.tsx
@@ -1,0 +1,20 @@
+import { SectionSchema } from '@/types/form-schema';
+import { useFormStore } from '@/store/formStore';
+import { FieldRenderer } from './FieldRenderer';
+
+interface Props {
+  section: SectionSchema;
+}
+
+export function SectionRenderer({ section }: Props) {
+  const { visibleSections, enabledSections } = useFormStore();
+  if (!visibleSections[section.id]) return null;
+  const disabled = !enabledSections[section.id];
+  return (
+    <div className={disabled ? 'opacity-50 pointer-events-none space-y-4' : 'space-y-4'}>
+      {section.fields.map((f) => (
+        <FieldRenderer key={f.id} field={f} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/playground/Playground.tsx
+++ b/src/components/playground/Playground.tsx
@@ -1,0 +1,25 @@
+import { useFormStore } from '@/store/formStore';
+import { Button } from '@/components/ui/button';
+import { FormRenderer } from '../form/FormRenderer';
+
+export function Playground() {
+  const { schemaText, setSchemaText, parseSchema, schema } = useFormStore();
+
+  return (
+    <div className="flex h-screen">
+      <div className="w-1/2 border-r flex flex-col">
+        <textarea
+          className="flex-1 w-full p-2 font-mono text-sm"
+          value={schemaText}
+          onChange={(e) => setSchemaText(e.target.value)}
+        />
+        <div className="p-2 border-t">
+          <Button onClick={parseSchema}>Render</Button>
+        </div>
+      </div>
+      <div className="flex-1 relative">
+        {schema ? <FormRenderer /> : <div className="p-4">Enter schema and render</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -13,7 +13,7 @@ import {
 } from "react-hook-form"
 
 import { cn } from "@/lib/utils"
-import { Label } from "@/registry/default/ui/label"
+import { Label } from "@/components/ui/label"
 
 const Form = FormProvider
 

--- a/src/lib/placeholder.ts
+++ b/src/lib/placeholder.ts
@@ -1,0 +1,23 @@
+export function resolvePlaceholders<T>(input: T, context: Record<string, any>): T {
+  if (typeof input === 'string') {
+    return input.replace(/{{(.*?)}}/g, (_, path) => {
+      const value = getByPath(context, path.trim());
+      return value != null ? String(value) : '';
+    }) as unknown as T;
+  }
+  if (Array.isArray(input)) {
+    return input.map((item) => resolvePlaceholders(item, context)) as unknown as T;
+  }
+  if (input && typeof input === 'object') {
+    const result: any = {};
+    for (const [key, value] of Object.entries(input as any)) {
+      result[key] = resolvePlaceholders(value, context);
+    }
+    return result;
+  }
+  return input;
+}
+
+function getByPath(obj: any, path: string): any {
+  return path.split('.').reduce((acc, part) => (acc ? acc[part] : undefined), obj);
+}

--- a/src/lib/rule-engine.ts
+++ b/src/lib/rule-engine.ts
@@ -1,0 +1,95 @@
+import { Action, Expression, RuleSchema, ValueRef } from '@/types/form-schema';
+
+export interface RuleEngineHelpers {
+  getValue: (field: string) => any;
+  context: Record<string, any>;
+  setFieldVisibility: (id: string, value: boolean) => void;
+  setFieldEnabled: (id: string, value: boolean) => void;
+  setSectionVisibility: (id: string, value: boolean) => void;
+  setSectionEnabled: (id: string, value: boolean) => void;
+  setValue: (field: string, value: any) => void;
+}
+
+export function runRules(rules: RuleSchema[] | undefined, helpers: RuleEngineHelpers) {
+  if (!rules) return;
+  for (const rule of rules) {
+    if (evaluateExpression(rule.condition, helpers)) {
+      for (const action of rule.actions) {
+        executeAction(action, helpers);
+      }
+    }
+  }
+}
+
+function evaluateExpression(expr: Expression, helpers: RuleEngineHelpers): boolean {
+  const left = resolveValueRef(expr.left, helpers);
+  const right = resolveValueRef(expr.right, helpers);
+  switch (expr.operator) {
+    case 'eq':
+      return left === right;
+    case 'neq':
+      return left !== right;
+    case 'gt':
+      return left > right;
+    case 'lt':
+      return left < right;
+    case 'includes':
+      return Array.isArray(left) ? left.includes(right) : false;
+    default:
+      return false;
+  }
+}
+
+function resolveValueRef(ref: ValueRef, helpers: RuleEngineHelpers): any {
+  switch (ref.type) {
+    case 'field':
+      return helpers.getValue(ref.value as string);
+    case 'context':
+      return getByPath(helpers.context, ref.value as string);
+    case 'literal':
+    default:
+      return ref.value;
+  }
+}
+
+function executeAction(action: Action, h: RuleEngineHelpers) {
+  const { targetType, targetId, effect, value } = action;
+  if (targetType === 'field') {
+    switch (effect) {
+      case 'show':
+        h.setFieldVisibility(targetId, true);
+        break;
+      case 'hide':
+        h.setFieldVisibility(targetId, false);
+        break;
+      case 'enable':
+        h.setFieldEnabled(targetId, true);
+        break;
+      case 'disable':
+        h.setFieldEnabled(targetId, false);
+        break;
+      case 'setValue':
+        h.setValue(targetId, value);
+        break;
+    }
+  } else if (targetType === 'section') {
+    switch (effect) {
+      case 'show':
+        h.setSectionVisibility(targetId, true);
+        break;
+      case 'hide':
+        h.setSectionVisibility(targetId, false);
+        break;
+      case 'enable':
+        h.setSectionEnabled(targetId, true);
+        break;
+      case 'disable':
+        h.setSectionEnabled(targetId, false);
+        break;
+    }
+  }
+}
+
+function getByPath(obj: any, path: string): any {
+  return path.split('.').reduce((acc, part) => (acc ? acc[part] : undefined), obj);
+}

--- a/src/store/formStore.ts
+++ b/src/store/formStore.ts
@@ -1,0 +1,72 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { FormSchema } from '@/types/form-schema';
+import { resolvePlaceholders } from '@/lib/placeholder';
+
+interface FormState {
+  schemaText: string;
+  schema: FormSchema | null;
+  contextValues: Record<string, any>;
+  currentSectionIndex: number;
+  visibleSections: Record<string, boolean>;
+  enabledSections: Record<string, boolean>;
+  visibleFields: Record<string, boolean>;
+  enabledFields: Record<string, boolean>;
+  setSchemaText: (text: string) => void;
+  setContextValues: (ctx: Record<string, any>) => void;
+  parseSchema: () => void;
+  setCurrentSection: (index: number) => void;
+  setFieldVisibility: (id: string, value: boolean) => void;
+  setFieldEnabled: (id: string, value: boolean) => void;
+  setSectionVisibility: (id: string, value: boolean) => void;
+  setSectionEnabled: (id: string, value: boolean) => void;
+}
+
+export const useFormStore = create<FormState>()(
+  devtools((set, get) => ({
+    schemaText: '',
+    schema: null,
+    contextValues: {},
+    currentSectionIndex: 0,
+    visibleSections: {},
+    enabledSections: {},
+    visibleFields: {},
+    enabledFields: {},
+    setSchemaText: (text) => set({ schemaText: text }),
+    setContextValues: (ctx) => set({ contextValues: ctx }),
+    parseSchema: () => {
+      try {
+        const raw = JSON.parse(get().schemaText);
+        const schema = resolvePlaceholders(raw, get().contextValues);
+        const visibleSections: Record<string, boolean> = {};
+        const enabledSections: Record<string, boolean> = {};
+        const visibleFields: Record<string, boolean> = {};
+        const enabledFields: Record<string, boolean> = {};
+        schema.sections.forEach((s) => {
+          visibleSections[s.id] = s.visible !== false;
+          enabledSections[s.id] = s.enabled !== false;
+          s.fields.forEach((f) => {
+            visibleFields[f.id] = f.visible !== false;
+            enabledFields[f.id] = f.enabled !== false;
+          });
+        });
+        set({ schema, visibleSections, enabledSections, visibleFields, enabledFields, currentSectionIndex: 0 });
+      } catch (e) {
+        console.error('Invalid schema', e);
+      }
+    },
+    setCurrentSection: (index) => set({ currentSectionIndex: index }),
+    setFieldVisibility: (id, value) => set((state) => ({
+      visibleFields: { ...state.visibleFields, [id]: value },
+    })),
+    setFieldEnabled: (id, value) => set((state) => ({
+      enabledFields: { ...state.enabledFields, [id]: value },
+    })),
+    setSectionVisibility: (id, value) => set((state) => ({
+      visibleSections: { ...state.visibleSections, [id]: value },
+    })),
+    setSectionEnabled: (id, value) => set((state) => ({
+      enabledSections: { ...state.enabledSections, [id]: value },
+    })),
+  }))
+);

--- a/src/types/form-schema.ts
+++ b/src/types/form-schema.ts
@@ -1,0 +1,53 @@
+export interface FormSchema {
+  sections: SectionSchema[];
+}
+
+export interface SectionSchema {
+  id: string;
+  title: string;
+  visible?: boolean;
+  enabled?: boolean;
+  fields: FieldSchema[];
+  rules?: RuleSchema[];
+}
+
+export interface FieldSchema {
+  id: string;
+  type: string;
+  label: string;
+  placeholder?: string;
+  options?: OptionSchema[];
+  defaultValue?: any;
+  visible?: boolean;
+  enabled?: boolean;
+  rules?: RuleSchema[];
+}
+
+export interface OptionSchema {
+  label: string;
+  value: string | number;
+}
+
+export interface RuleSchema {
+  event: 'load' | 'change' | 'submit';
+  condition: Expression;
+  actions: Action[];
+}
+
+export interface Expression {
+  left: ValueRef;
+  operator: 'eq' | 'neq' | 'gt' | 'lt' | 'includes';
+  right: ValueRef;
+}
+
+export type ValueRef =
+  | { type: 'field'; value: string }
+  | { type: 'context'; value: string }
+  | { type: 'literal'; value: any };
+
+export interface Action {
+  targetType: 'field' | 'section';
+  targetId: string;
+  effect: 'show' | 'hide' | 'enable' | 'disable' | 'setValue';
+  value?: any;
+}


### PR DESCRIPTION
## Summary
- add JSON-schema powered playground for dynamic form rendering
- implement rule engine with visibility and enablement actions
- include devtools to inspect form state

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a48e799f288322a05211d05b8dc12d